### PR TITLE
Upgrade isbot major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "v1rtl",
   "license": "MIT",
   "dependencies": {
-    "isbot": "^3.6.10"
+    "isbot": "^4.1.1"
   },
   "scripts": {
     "build": "rollup -c",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   isbot:
-    specifier: ^3.6.10
-    version: 3.6.10
+    specifier: ^4.1.1
+    version: 4.1.1
 
 devDependencies:
   '@rollup/plugin-typescript':
@@ -1206,9 +1210,9 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /isbot@3.6.10:
-    resolution: {integrity: sha512-+I+2998oyP4oW9+OTQD8TS1r9P6wv10yejukj+Ksj3+UR5pUhsZN3f8W7ysq0p1qxpOVNbl5mCuv0bCaF8y5iQ==}
-    engines: {node: '>=12'}
+  /isbot@4.1.1:
+    resolution: {integrity: sha512-kN+jdL5T+4kMfENZzLwv81KFymnpuv49rUQpp6jwHQhqMG++f1XPvNBgFRO9N0uaBqqft1d+Vn1Jls/TDhJpDw==}
+    engines: {node: '>=18'}
     dev: false
 
   /isexe@2.0.0:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { IncomingMessage as Request } from 'http'
-import detectBot from 'isbot'
+import { isbot, isbotMatch } from 'isbot'
 
 export interface RequestWithBotDetector extends Request {
   isBot: boolean
@@ -20,13 +20,13 @@ export function botDetector() {
       isBot: {
         get: () => {
           if (typeof bot === 'boolean') return bot
-          return (bot = detectBot(agent))
+          return (bot = isbot(agent))
         }
       },
       botName: {
         get: () => {
           if (!req.isBot) name = null
-          if (typeof name === 'undefined') name = detectBot.find(agent)
+          if (typeof name === 'undefined') name = isbotMatch(agent)
 
           return name || undefined
         }


### PR DESCRIPTION
Migrate isbot to version >= 4. Uses names exports

See migration guide: https://github.com/omrilotan/isbot/blob/main/CHANGELOG.md#400